### PR TITLE
Fixed puppetlabs-stdlib dependency to 4.6.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 3.2.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0"},
     {"name":"puppetlabs-concat","version_requirement":">= 1.1.0 <= 1.2.2"}
   ]
 }


### PR DESCRIPTION
as validate_integer is used, which wasn't available in earlier versions