### PR TITLE
Validation and dependency changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -440,9 +440,9 @@ class auditd (
   validate_bool($service_enable)
 
   # Install package
-  package { 'auditd':
+  package { $package_name:
     ensure => 'present',
-    name   => $package_name,
+    alias  => 'auditd',
     before => [
       File['/etc/audit/auditd.conf'],
       File['/etc/audisp/audispd.conf'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -466,7 +466,7 @@ class auditd (
       mode    => '0750',
       recurse => true,
       purge   => true,
-      before  => Concat['audit-file'],
+      require => Package[$package_name],
     }
   }
   concat { $rules_file:

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -9,7 +9,7 @@ define auditd::rule($content='', $order=10) {
     $body = $content
   }
 
-  validate_integer($order)
+  validate_numeric($order)
   validate_string($body)
 
   concat::fragment{ "auditd_fragment_${name}":

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -51,9 +51,10 @@ describe 'auditd', :type => :class do
   end
   context 'default parameters on Amazon Linux' do
     let (:facts) {{
-      :osfamily        => 'RedHat',
-      :operatingsystem => 'Amazon',
-      :concat_basedir  => '/var/lib/puppet/concat',
+      :osfamily               => 'RedHat',
+      :operatingsystemrelease => '7',
+      :operatingsystem        => 'Amazon',
+      :concat_basedir         => '/var/lib/puppet/concat',
     }}
     it {
       should contain_service('auditd').with({


### PR DESCRIPTION
Hi,

I'm seeing weird behaviour with audit rules defined in hiera. If I define like this:-

`auditd::rules:
  'watch for 64bit time adjustment syscalls':
    content: '-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change'
    order: '11'`

Then it works fine. If I start my rules at 01 (following the examples):-

`auditd::rules:
  'watch for 64bit time adjustment syscalls':
    content: '-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change'
    order: '01'`

I get the following output:-

==> proxy01: Error: validate_integer(): Expected first argument to be an Integer or Array, got String at /tmp/vagrant-puppet/modules-b4ec57d5effff311429132a4b4ccc8ae/auditd/manifests/rule.pp:12 on node proxy01.fco-etd.local

Quoting makes no difference to the output but if I start at 11 it works fine.

Also the dependecies seem to be off:-

With dependency set as Concat['audit-file'] for /etc/audit/rules.d the module does not work as it's possible for this to run before auditd is installed and /etc/audit does not yet exist. Setting to package but could be anything else appropriate.

==> proxy01: Error: Cannot create /etc/audit/rules.d; parent directory /etc/audit does not exist
==> proxy01: Error: /Stage[main]/Auditd/File[/etc/audit/rules.d]/ensure: change from absent to directory failed: Cannot create /etc/audit/rules.d; parent directory /etc/audit does not exist

Thanks,

Not saying this is the right thing to do but it solves my problem!
