### PR TITLE
Fix nil auditd.conf parameters and Amazon Linux check

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class auditd::params {
       $audisp_package     = 'audispd-plugins'
       $manage_audit_files = true
 
-      if versioncmp($::operatingsystemrelease, '7') >= 0 and $::operatingsystem != 'Amazon' {
+      if $::operatingsystem != 'Amazon' and versioncmp($::operatingsystemrelease, '7') >= 0 {
         $rules_file      = '/etc/audit/rules.d/puppet.rules'
         $service_restart = '/usr/libexec/initscripts/legacy-actions/auditd/restart'
         $service_stop    = '/usr/libexec/initscripts/legacy-actions/auditd/stop'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -117,4 +117,13 @@ describe 'auditd', :type => :class do
       })
     }
   end
+  context 'auditd.conf is well-formed' do
+    let (:facts) {{
+      :osfamily               => 'RedHat',
+      :operatingsystemrelease => '7',
+    }}
+    it {
+      should_not contain_file('/etc/audit/auditd.conf').with_content(/=\s*$/)
+    }
+  end
 end

--- a/templates/auditd.conf.erb
+++ b/templates/auditd.conf.erb
@@ -21,17 +21,17 @@ admin_space_left = <%= @admin_space_left %>
 admin_space_left_action = <%= @admin_space_left_action %>
 disk_full_action = <%= @disk_full_action %>
 disk_error_action = <%= @disk_error_action %>
-<% if @tcp_listen_port.nil? %>
+<% unless @tcp_listen_port.nil? %>
 tcp_listen_port = <%= @tcp_listen_port %>
 <% end -%>
 tcp_listen_queue = <%= @tcp_listen_queue %>
 tcp_max_per_addr = <%= @tcp_max_per_addr %>
-<% if @tcp_client_ports.nil? %>
+<% unless @tcp_client_ports.nil? %>
 tcp_client_ports = <%= @tcp_client_ports %>
 <% end -%>
 tcp_client_max_idle = <%= @tcp_client_max_idle %>
 enable_krb5 = <%= @enable_krb5 %>
 krb5_principal = <%= @krb5_principal %>
-<% if @krb5_key_file.nil? %>
+<% unless @krb5_key_file.nil? %>
 krb5_key_file = <%= @krb5_key_file %>
 <% end -%>


### PR DESCRIPTION
The auditd.conf template currently creates a malformed auditd.conf file if you do not specify the optional params when you initialise the class (tcp_listen_port, tcp_client_ports, krb5_key_file). This results in the service not starting. I've also added a test to check that there are no blank config settings in the produced config file.

The check for Amazon Linux versioncmp also does not work because $::operatingsystemrelease on Amazon Linux is a String, e.g. "2016.03". This resulted in a failing test. I've moved the $::operatingsystem check to after checking for Amazon Linux, relying on the short-circuit evaluation to work its magic. 