### PR TITLE
Fix running on Centos 5.3 ("tcp_max_per_addr")

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -408,7 +408,9 @@ class auditd (
     validate_integer($tcp_listen_port)
   }
   validate_integer($tcp_listen_queue)
-  validate_integer($tcp_max_per_addr)
+  if $tcp_max_per_addr != undef {
+    validate_integer($tcp_max_per_addr)
+  }
   if $tcp_client_ports != undef {
     validate_string($tcp_client_ports)
   }

--- a/templates/auditd.conf.erb
+++ b/templates/auditd.conf.erb
@@ -25,7 +25,9 @@ disk_error_action = <%= @disk_error_action %>
 tcp_listen_port = <%= @tcp_listen_port %>
 <% end -%>
 tcp_listen_queue = <%= @tcp_listen_queue %>
+<% unless @tcp_max_per_addr.nil? %>
 tcp_max_per_addr = <%= @tcp_max_per_addr %>
+<% end -%>
 <% unless @tcp_client_ports.nil? %>
 tcp_client_ports = <%= @tcp_client_ports %>
 <% end -%>


### PR DESCRIPTION
So we can set "tcp_max_per_addr => undef,".