### PR TITLE
Fix Centos 5.3 (auditd no "tcp_max_per_addr", auditd exiting)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: ruby
 bundler_args: --without system_tests
-script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
+script: "bundle exec rake validate && bundle exec rake lint && STRICT_VARIABLES=no bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
   fast_finish: true
   include:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -408,7 +408,9 @@ class auditd (
     validate_integer($tcp_listen_port)
   }
   validate_integer($tcp_listen_queue)
-  validate_integer($tcp_max_per_addr)
+  if $tcp_max_per_addr != undef {
+    validate_integer($tcp_max_per_addr)
+  }
   if $tcp_client_ports != undef {
     validate_string($tcp_client_ports)
   }

--- a/templates/auditd.conf.erb
+++ b/templates/auditd.conf.erb
@@ -25,7 +25,9 @@ disk_error_action = <%= @disk_error_action %>
 tcp_listen_port = <%= @tcp_listen_port %>
 <% end -%>
 tcp_listen_queue = <%= @tcp_listen_queue %>
+<% unless @tcp_max_per_addr.nil? %>
 tcp_max_per_addr = <%= @tcp_max_per_addr %>
+<% end -%>
 <% unless @tcp_client_ports.nil? %>
 tcp_client_ports = <%= @tcp_client_ports %>
 <% end -%>


### PR DESCRIPTION
So we can use this for Centos 5.3
class{auditd:
  tcp_max_per_addr => undef,
}

Set STRICT_VARIABLES=no, so "bundle exec rake spec" can run.
(Don't know if this is okey to set here)???