### PR TITLE
add support for write_logs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ This  keyword  specifies  the  group  that is applied to the log file's permissi
 
 Default: `root`
 
+#### `write_logs`
+
+This yes/no keyword determines whether or not to write logs to the disk. There are two options: yes and no. It is meant to replace the usage of `log_format = NOLOG`. This will default to undef since it is only available in version >= 2.5.2.
+
+Default: `undef`
+
 #### `priority_boost`
 
 This is a non-negative number that tells the audit damon how much of a priority boost it should take. The default is 3. No change is 0.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,12 @@
 #   permissions. The default is root. The group name can be either numeric
 #   or spelled out.
 #
+# [*write_logs*]
+#   This yes/no keyword determines whether or not to write logs to the disk.
+#   There are two options: yes and no. It is meant to replace the usage of
+#   log_format = NOLOG. This will default to undef since it is only available
+#   in version >= 2.5.2.
+#
 # [*priority_boost*]
 #   This is a non-negative number that tells the audit damon how much of
 #   a priority boost it should take. The default is 3. No change is 0.
@@ -321,6 +327,7 @@ class auditd (
   $log_file                = $::auditd::params::log_file,
   $log_format              = $::auditd::params::log_format,
   $log_group               = $::auditd::params::log_group,
+  $write_logs              = $::auditd::params::write_logs,
   $priority_boost          = $::auditd::params::priority_boost,
   $flush                   = $::auditd::params::flush,
   $freq                    = $::auditd::params::freq,
@@ -379,6 +386,10 @@ class auditd (
   validate_re($log_format, '^(RAW|NOLOG)$',
     "${log_format} is not supported for log_format. Allowed values are 'RAW' and 'NOLOG'.")
   validate_string($log_group)
+  if $write_logs != undef {
+    validate_re($write_logs, '^(yes|no)$',
+      "${write_logs} is not supported for write_logs. Allowed values are 'yes' and 'no'.")
+  }
   validate_integer($priority_boost)
   validate_re($flush, '^(none|incremental|data|sync)$',
     "${flush} is not supported for flush. Allowed values are 'none', 'incremental', 'data' and 'sync'.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,6 +76,7 @@ class auditd::params {
   $log_file                = '/var/log/audit/audit.log'
   $log_format              = 'RAW'
   $log_group               = 'root'
+  $write_logs              = undef
   $priority_boost          = '4'
   $flush                   = 'incremental'
   $freq                    = '20'

--- a/templates/auditd.conf.erb
+++ b/templates/auditd.conf.erb
@@ -4,6 +4,9 @@
 log_file = <%= @log_file %>
 log_format = <%= @log_format %>
 log_group = <%= @log_group %>
+<% unless @write_logs.nil? %>
+write_logs = <%= @write_logs %>
+<% end -%>
 priority_boost = <%= @priority_boost %>
 flush = <%= @flush %>
 freq = <%= @freq %>


### PR DESCRIPTION
This option is available in audit >= 2.5.2. `log_format = NOLOG` has been deprecated. Instead, using `write_logs = no` is preferred. By having the option default to `undef`, we can maintain backwards-compatibility for everyone.

Details can be seen here: https://people.redhat.com/sgrubb/audit/ChangeLog
