### PR TITLE
Add support for the `audisp-cef` plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yaml,yml,json,pp,rb,erb}]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ This module handles installation of the auditd daemon, manages its main configur
 
 ### Setup Requirements
 
-Arch Linux does not compile in auditing support to their Kernel by default. To enable support you will have to enable this support as per [this Arch Wiki page](https://wiki.archlinux.org/index.php/Audit_framework#Installation).
+Arch Linux does not compile in auditing support to their Kernel by default. To enable support you will have to enable this support as per [this Arch Wiki page](https://wiki.archlinux.org/index.php/Audit_framework#Installation). Other supported Linux distros should not need any special setup.
 
-Other supported Linux distros should not need any special setup.
+When the `audisp-cef` plugin is used, the `auditd::audisp::cef` class depends on the `audisp-cef` package, which may not be provided by your distibution's default repositories. The `deb` and `npm` targets in [audisp-cef](https://github.com/gdestuynder/audisp-cef)'s makefile can be used to package the plugin, ready to deploy to your own repository.
 
 ### Beginning with auditd
 
@@ -175,6 +175,29 @@ To use this plugin:
 include '::auditd'
 include '::auditd::audisp::audispd_zos_remote'
 ```
+
+#### cef
+
+This plugin aggregates events with the same message ID and writes them to syslog as a single message in the Common Event Format. Documentation for messages produced by this plugin can be found [here](https://github.com/gdestuynder/audisp-cef/blob/master/messages_format.rst). Depends on the `audisp-cef` package; see the [Setup Requirements](#setup-requirements).
+
+To use this plugin:
+
+```puppet
+include '::auditd'
+include '::auditd:audisp::cef'
+```
+
+Optionally, the syslog facility to use for messages can be specified as an integer:
+
+```puppet
+include '::auditd'
+class { '::auditd::audisp::cef':
+    # Facility 'local5' is 21 << 3
+    facility => 168,
+}
+```
+
+`168` is the default.
 
 #### syslog
 

--- a/manifests/audisp/cef.pp
+++ b/manifests/audisp/cef.pp
@@ -1,10 +1,6 @@
 class auditd::audisp::cef (
   #local5 is 21<<3
   $facility = 168,
-
-  # These two are possibly unused
-  $remote_server = '127.0.0.1',
-  $port = 514
 ) {
 
   package { 'audisp-cef':

--- a/manifests/audisp/cef.pp
+++ b/manifests/audisp/cef.pp
@@ -10,7 +10,7 @@ class auditd::audisp::cef (
     path => '/sbin/audisp-cef',
   }
 
-  file { "/etc/audisp/audisp-cef.conf":
+  file { '/etc/audisp/audisp-cef.conf':
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',

--- a/manifests/audisp/cef.pp
+++ b/manifests/audisp/cef.pp
@@ -1,0 +1,26 @@
+class auditd::audisp::cef (
+  #local5 is 21<<3
+  $facility = 168,
+
+  # These two are possibly unused
+  $remote_server = '127.0.0.1',
+  $port = 514
+) {
+
+  package { 'audisp-cef':
+    ensure => 'present',
+  } ->
+  auditd::audisp::plugin { 'au-cef':
+    path => '/sbin/audisp-cef',
+  }
+
+  file { "/etc/audisp/audisp-cef.conf":
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+    content => template("${module_name}/audisp-cef.conf.erb"),
+    notify  => Service['auditd'],
+  }
+
+}

--- a/templates/audisp-cef.conf.erb
+++ b/templates/audisp-cef.conf.erb
@@ -1,0 +1,8 @@
+#
+# This file is managed by Puppet.
+#
+facility = <%= @facility %>
+
+#unused
+remote_server = <%= @remote_server %>
+port = <%= @port %>

--- a/templates/audisp-cef.conf.erb
+++ b/templates/audisp-cef.conf.erb
@@ -2,7 +2,3 @@
 # This file is managed by Puppet.
 #
 facility = <%= @facility %>
-
-#unused
-remote_server = <%= @remote_server %>
-port = <%= @port %>

--- a/templates/audisp.plugin.erb
+++ b/templates/audisp.plugin.erb
@@ -3,8 +3,8 @@
 #
 active = <%= @real_active %>
 direction = <%= @direction %>
+type = <%= @type %>
 path = <%= @path %>
-type = <%= @type -%>
 <% if @args %>
 args = <%= @args %>
 <% end -%>


### PR DESCRIPTION
`audisp-cef` is an audisp plugin which aggregates audit messages with the same ID into a single syslog message in the Common Event Format.

The plugin is [published on Github](https://github.com/gdestuynder/audisp-cef) and the makefile provides targets for making `.deb` and `.npm` packages. At this time these packages do not appear to be provided by the default repositories in Ubuntu or CentOS. Users wishing to deploy this plugin can in these cases provide the `audisp-cef` package through their own repository.

Of course, the `audisp-cef` package is only depended on if the plugin's class is explicitly used, so I hope this patch is still acceptable.