### PR TITLE
Remove the line-ending chomp from plugin template

### DIFF
--- a/templates/audisp.plugin.erb
+++ b/templates/audisp.plugin.erb
@@ -7,5 +7,5 @@ type = <%= @type %>
 path = <%= @path %>
 <% if @args %>
 args = <%= @args %>
-<% end -%>
+<% end %>
 format = <%= @format %>


### PR DESCRIPTION
If the plugin is enabled without arguments, the generated configuration is invalid. The path and format lines are joined together.

The following is an excerpt from a puppet run against a host. Notice the formatting of the last line.
```
Info: Concat[/etc/audit/rules.d/puppet.rules]: Scheduling refresh of Service[auditd]
Notice: /Stage[main]/Auditd::Audisp::Au_remote/Auditd::Audisp::Plugin[au-remote]/File[/etc/audisp/plugins.d/au-remote.conf]/content: 
--- /etc/audisp/plugins.d/au-remote.conf	2017-03-03 03:42:46.000000000 +0000
+++ /tmp/puppet-file20170616-95-11fdky8	2017-06-16 20:11:24.238137318 +0000
@@ -1,12 +1,7 @@
-
-# This file controls the audispd data path to the
-# remote event logger. This plugin will send events to
-# a remote machine (Central Logger).
-
-active = no
+#
+# This file is managed by Puppet.
+#
+active = yes
 direction = out
 path = /sbin/audisp-remote
-type = always
-#args =
-format = string
-
+type = alwaysformat = string

Info: Computing checksum on file /etc/audisp/plugins.d/au-remote.conf
```