### PR TITLE
Remove 'alias' metaparameter from concat resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -459,7 +459,7 @@ class auditd (
     before => [
       File['/etc/audit/auditd.conf'],
       File['/etc/audisp/audispd.conf'],
-      Concat['audit-file'],
+      Concat[$rules_file],
     ],
   }
 
@@ -489,7 +489,6 @@ class auditd (
     mode           => '0640',
     ensure_newline => true,
     warn           => true,
-    alias          => 'audit-file',
   }
   concat::fragment{ 'auditd_rules_begin':
     target  => $rules_file,
@@ -520,7 +519,7 @@ class auditd (
       subscribe => [
         File['/etc/audit/auditd.conf'],
         File['/etc/audisp/audispd.conf'],
-        Concat['audit-file'],
+        Concat[$rules_file],
       ],
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -26,7 +26,9 @@ describe 'auditd', :type => :class do
         'mode'           => '0640',
         'ensure_newline' => 'true',
         'warn'           => 'true',
-        'alias'          => 'audit-file',
+      })
+      should_not contain_concat('/etc/audit/rules.d/puppet.rules').with({
+        'alias' => 'audit-file',
       })
       should contain_service('auditd').with({
         'ensure'    => 'running',


### PR DESCRIPTION
Under Puppet 5 (and possibly Puppet 4) setting the 'alias' metaparameter
and referencing the concat resource by the alias name leads to errors
like this during catalog compilation:

```
Error:
/Stage[main]/Auditd/Concat[/etc/audit/audit.rules]/Concat_file[/etc/audit/audit.rules]:
  Failed to generate additional resources using 'generate': Parameter
  alias failed on File[/etc/audit/audit.rules]: Munging failed for value
  ["audit-file"] in class alias: Cannot add aliases without a catalog
```

But there is no need to even use the alias metaparameter when the concat
resource can just as easily be referenced by its resource name
(i.e. `$rules_file`), so this change removes the alias metaparameter and
updates the concat resource references to use the resource title.

This way the module is compatible with Puppet 5.