### PR TITLE
Improvement syslog class

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ You can change the `args` for this plugin:
 ```puppet
 include '::auditd'
 class { '::auditd::audisp::syslog':
+  # Default value is false, which will keep remain disabled logging to syslog even though you call class '::auditd::audisp::syslog'
+  active => true,
   # LOG_INFO is actually the default...
   args => 'LOG_INFO',
 }

--- a/README.md
+++ b/README.md
@@ -215,10 +215,11 @@ You can change the `args` for this plugin:
 ```puppet
 include '::auditd'
 class { '::auditd::audisp::syslog':
-  # Default value is false, which will keep remain disabled logging to syslog even though you call class '::auditd::audisp::syslog'
+  # Default value is false, which will keep remain disabled logging 
+  # to syslog even though you call class '::auditd::audisp::syslog'
   active => true,
   # LOG_INFO is actually the default...
-  args => 'LOG_INFO',
+  args   => 'LOG_INFO',
 }
 ```
 

--- a/manifests/audisp/plugin.pp
+++ b/manifests/audisp/plugin.pp
@@ -1,5 +1,5 @@
 define auditd::audisp::plugin (
-  $active    = true,
+  $active    = false,
   $direction = 'out',
   $path      = undef,
   $type      = 'always',

--- a/manifests/audisp/syslog.pp
+++ b/manifests/audisp/syslog.pp
@@ -1,11 +1,13 @@
 class auditd::audisp::syslog (
-  $args = 'LOG_INFO',
+  $active = flase,
+  $args   = 'LOG_INFO',
 
 ) {
 
   auditd::audisp::plugin { 'syslog':
     path    => 'builtin_syslog',
     type    => 'builtin',
+    active  => $active,
     args    => $args,
     require => Package['auditd'],
   }


### PR DESCRIPTION
Because enabling auidt log into syslog might be causing the system overhead.
So make sure if someone really want to enable this.

https://github.com/kemra102/puppet-auditd/issues/39