### PR TITLE
Fix target for concat::fragment

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -16,7 +16,7 @@ define auditd::rule($content='', $order=10) {
   validate_string($body)
 
   concat::fragment{ "auditd_fragment_${name}":
-    target  => $auditd::params::rules_file,
+    target  => $auditd::rules_file,
     order   => $order,
     content => $body,
   }


### PR DESCRIPTION
When specifying a different `rules_file`, the fragments were using the `rules_file` from `params.pp`, and not the one provided by e.g. Hiera.