### PR TITLE
use 2.4.1 ruby for puppet 4.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ script: "bundle exec rake validate && bundle exec rake lint && STRICT_VARIABLES=
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.9
+  - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 4.6"
-  - rvm: 2.1.9
+  - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 4.10"
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5.0"


### PR DESCRIPTION
after the following commit 

https://github.com/kemra102/puppet-auditd/commit/00afc2d26d2ae9ce3413778f66a233fa1f908fc3

all build is failed 