### PR TITLE
fix numeric rule ordering

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -492,6 +492,7 @@ class auditd (
     owner          => 'root',
     group          => 'root',
     mode           => '0640',
+    order          => 'numeric',
     ensure_newline => true,
     warn           => true,
   }


### PR DESCRIPTION
Numeric is used everywhere in the code and examples, but concat isn't numeric by default.