### PR TITLE
Change the default flush value to 'incremental'

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -78,7 +78,7 @@ class auditd::params {
   $log_group               = 'root'
   $write_logs              = undef
   $priority_boost          = '4'
-  $flush                   = 'incremental_async'
+  $flush                   = 'incremental'
   $freq                    = '20'
   $num_logs                = '5'
   $disp_qos                = 'lossy'


### PR DESCRIPTION
The flush value 'incremental_async' is not supported in Ubuntu 16.04/Debian 8 and earlier.