### PR TITLE
Add support for RHEL8

### DIFF
--- a/manifests/audisp/plugin.pp
+++ b/manifests/audisp/plugin.pp
@@ -1,11 +1,11 @@
 define auditd::audisp::plugin (
-  $active    = true,
-  $direction = 'out',
-  $path      = undef,
-  $type      = 'always',
-  $args      = undef,
-  $format    = 'string',
-
+  $active     = true,
+  $direction  = 'out',
+  $path       = undef,
+  $type       = 'always',
+  $args       = undef,
+  $format     = 'string',
+  $audisp_dir = $::audisp::params::audisp_dir
 ) {
 
   validate_bool($active)
@@ -27,7 +27,7 @@ define auditd::audisp::plugin (
     $real_active = 'no'
   }
 
-  file { "/etc/audisp/plugins.d/${name}.conf":
+  file { "${audisp_dir}/plugins.d/${name}.conf":
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -515,7 +515,7 @@ class auditd (
   }
 
   # If a hash of rules is supplied with class then call auditd::rules defined type to apply them
-  $rules.each |$key,$opts| { 
+  $rules.each |$key,$opts| {
     auditd::rule { $key:
       * => pick($opts,{}),
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,8 @@ class auditd::params {
       $audisp_package     = 'audispd-plugins'
       $manage_audit_files = false
       $rules_file         = '/etc/audit/rules.d/audit.rules'
+      $has_audisp_config  = true
+      $audisp_dir         = '/etc/audisp'
 
       case $::lsbmajdistrelease {
         '8': {
@@ -21,6 +23,8 @@ class auditd::params {
     }
     'Suse': {
       $package_name       = 'audit'
+      $has_audisp_config  = true
+      $audisp_dir         = '/etc/audisp'
       if versioncmp($::operatingsystemrelease, '12') >= 0 and $::operatingsystem == 'SLES' {
         $audisp_package     = 'audit-audispd-plugins'
         $manage_audit_files = true
@@ -41,6 +45,14 @@ class auditd::params {
       $audisp_package     = 'audispd-plugins'
       $manage_audit_files = true
 
+      if versioncmp($::operatingsystemrelease, '8') >= 0 {
+        $has_audisp_config = false
+        $audisp_dir        = '/etc/auditd'
+      } else {
+        $has_audisp_config = true
+        $audisp_dir        = '/etc/audisp'
+      }
+
       if $::operatingsystem != 'Amazon' and versioncmp($::operatingsystemrelease, '7') >= 0 {
         $rules_file      = '/etc/audit/rules.d/puppet.rules'
         $service_restart = '/usr/libexec/initscripts/legacy-actions/auditd/restart'
@@ -58,6 +70,8 @@ class auditd::params {
       $rules_file         = '/etc/audit/audit.rules'
       $service_restart    = '/usr/bin/kill -s SIGHUP $(cat /var/run/auditd.pid)'
       $service_stop       = '/usr/bin/kill -s SIGTERM $(cat /var/run/auditd.pid)'
+      $has_audisp_config  = true
+      $audisp_dir         = '/etc/audisp'
     }
     'Gentoo': {
       $package_name       = 'audit'
@@ -66,6 +80,8 @@ class auditd::params {
       $rules_file         = '/etc/audit/audit.rules'
       $service_restart    = '/etc/init.d/auditd restart'
       $service_stop       = '/etc/init.d/auditd stop'
+      $has_audisp_config  = true
+      $audisp_dir         = '/etc/audisp'
     }
     default: {
       fail("${::osfamily} is not supported by auditd")

--- a/templates/auditd.conf.erb
+++ b/templates/auditd.conf.erb
@@ -40,3 +40,14 @@ krb5_principal = <%= @krb5_principal %>
 <% unless @krb5_key_file.nil? %>
 krb5_key_file = <%= @krb5_key_file %>
 <% end -%>
+<% unless @has_audisp_config %>
+# Audisp settings:
+q_depth = <%= @audisp_q_depth %>
+overflow_action = <%= @audisp_overflow_action %>
+priority_boost = <%= @audisp_priority_boost %>
+max_restarts = <%= @audisp_max_restarts %>
+name_format = <%= @audisp_name_format %>
+<% if @audisp_name %>
+name = <%= @audisp_name %>
+<% end -%>
+<% end %>


### PR DESCRIPTION
As described here; https://access.redhat.com/solutions/3806561, RedHat stopped with the path `/etc/audisp` and all settings in audispd.conf are now supported in auditd.conf. From: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#audispd_security

> With this update, functionality of audispd has been moved to auditd. As a result, audispd configuration options are now part of auditd.conf. In addition, the plugins.d directory has been moved under /etc/audit. The current status of auditd and its plug-ins can now be checked by running the service auditd state command.

With this change the settings of audispd.conf are moved to auditd.conf. The path `/etc/audisp` is not managed anymore. Also the plugins for RHEL8 are moved to `/etc/auditd/plugins.d`